### PR TITLE
Allow sub project builds and semver tags

### DIFF
--- a/.github/actions/get-next-version/action.yml
+++ b/.github/actions/get-next-version/action.yml
@@ -11,11 +11,16 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - run: pip install requests
+    - run: pip install requests semver
       shell: bash
     - id: next-tag
       run: |
-         import requests
+         import requests, re, semver
          json = requests.get("${{ github.api_url }}/repos/nationalarchives/${{ inputs.repo-name }}/tags").json()
-         print(f"::set-output name=next-version::v{int(json[0]['name'][1:]) + 1}")
+         version = json[0]['name']
+         if re.search("v\d*$", version) != None:
+           print(f"::set-output name=next-version::v{int(version[1:]) + 1}")
+         else:
+           next_version = str(semver.parse_version_info(version[1:]).bump_patch())
+           print(f"::set-output name=next-version::v{next_version}")
       shell: python

--- a/.github/workflows/lambda_build.yml
+++ b/.github/workflows/lambda_build.yml
@@ -44,7 +44,7 @@ jobs:
           role-session-name: GitHubActionsRole
       - run: pip install requests
       - id: next-tag
-        uses: nationalarchives/tdr-github-actions/.github/actions/get-next-version@main
+        uses: nationalarchives/tdr-github-actions/.github/actions/get-next-version@allow-sub-project-builds
         with:
           repo-name: ${{ inputs.repo-name }}
       - name: Build new image version

--- a/.github/workflows/lambda_build.yml
+++ b/.github/workflows/lambda_build.yml
@@ -44,7 +44,7 @@ jobs:
           role-session-name: GitHubActionsRole
       - run: pip install requests
       - id: next-tag
-        uses: nationalarchives/tdr-github-actions/.github/actions/get-next-version@allow-sub-project-builds
+        uses: nationalarchives/tdr-github-actions/.github/actions/get-next-version@main
         with:
           repo-name: ${{ inputs.repo-name }}
       - name: Build new image version

--- a/.github/workflows/lambda_build.yml
+++ b/.github/workflows/lambda_build.yml
@@ -11,6 +11,10 @@ on:
       artifact-name:
         required: true
         type: string
+      artifact-path:
+        required: false
+        type: string
+        default: target/scala-2.13
     secrets:
       MANAGEMENT_ACCOUNT:
         required: true
@@ -47,8 +51,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: |
-          sbt assembly
-          aws s3 cp target/scala-2.13/${{ inputs.artifact-name }}.jar s3://tdr-backend-code-mgmt/${{ steps.next-tag.outputs.next-version }}/${{ inputs.artifact-name }}.jar
+          ${{ inputs.build-command }}
+          aws s3 cp ${{ inputs.artifact-path }}/${{ inputs.artifact-name }}.jar s3://tdr-backend-code-mgmt/${{ steps.next-tag.outputs.next-version }}/${{ inputs.artifact-name }}.jar
           git tag ${{ steps.next-tag.outputs.next-version }}
           git push origin ${{ steps.next-tag.outputs.next-version }}
-          gh release create ${{ steps.next-tag.outputs.next-version }} target/scala-2.13/${{ inputs.artifact-name }}.jar
+          gh release create ${{ steps.next-tag.outputs.next-version }} ${{ inputs.artifact-path }}/${{ inputs.artifact-name }}.jar


### PR DESCRIPTION
This uses an optional parameter to find the built jar so we can do lambda/target/scala-2.13
I've also updated the get-next-version action so it will work with semver tags as well as the v100 ones we use elsewhere.
