### PR TITLE
Add wait parameter to e2e tests call

### DIFF
--- a/.github/workflows/ecs_deploy.yml
+++ b/.github/workflows/ecs_deploy.yml
@@ -81,6 +81,6 @@ jobs:
         with:
           route: POST /repos/nationalarchives/tdr-e2e-tests/actions/workflows/ci.yml/dispatches
           ref: master
-          inputs: "{\"environment\": \"${{ inputs.environment }}\"}"
+          inputs: "{\"environment\": \"${{ inputs.environment }}\", \"wait\": \"300\"}"
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
The e2e tests job has been updated to take a wait parameter which makes
it sleep for x seconds.

I've added in the parameter here to give the load balancer time to
switch to the new version.
