### PR TITLE
Set workspace as safe

### DIFF
--- a/.github/actions/run-git-secrets/entrypoint.sh
+++ b/.github/actions/run-git-secrets/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh -l
+git config --global --add safe.directory '/github/workspace' && \
 git-secrets --register-aws --global && \
 git-secrets --add --global '([^0-9])*[0-9]{12}([^0-9])*'
 git-secrets --add --global --allowed '1234'


### PR DESCRIPTION
Git suggest making this change.

Due to a security alert: https://github.blog/2022-04-12-git-security-vulnerability-announced/

See this stackoverflow thread: https://stackoverflow.com/questions/71849415/cannot-add-parent-directory-to-safe-directory-on-git