### PR TITLE
Allow other working directories for terraform check

### DIFF
--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -6,6 +6,10 @@ on:
         type: boolean
         required: false
         default: true
+      working-directory:
+        type: string
+        required: false
+        default: .
     secrets:
       MANAGEMENT_ACCOUNT:
         required: true
@@ -14,6 +18,9 @@ on:
 jobs:
   terraform-check:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: inputs.working-directory
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: inputs.working-directory
+        working-directory: ${{ inputs.working-directory }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Allow other working directories
    
Terraform is not always run from the root directory. This allows another one to be specified

