### PR TITLE
Add terraform apply job

### DIFF
--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -21,6 +21,12 @@ on:
         required: true
       ACCOUNT_NUMBER:
         required: true
+      INTG_ACCOUNT_NUMBER:
+        required: false
+      STAGING_ACCOUNT_NUMBER:
+        required: false
+      PROD_ACCOUNT_NUMBER:
+        required: false
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -9,6 +9,9 @@ on:
       repo-name:
         type: string
         required: true
+      environment:
+        type: string
+        required: true
     secrets:
       MANAGEMENT_ACCOUNT:
         required: true

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -71,7 +71,7 @@ jobs:
       - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
         with:
           message: |
-            :book: Terraform plan ready for environment ${{ inputs.environment }}
+            :book: Terraform plan ready for repository ${{ inputs.repo-name }} environment ${{ inputs.environment }}
             :log: View the <${{ steps.plan.outputs.log-url }}|plan logs> in the management account.
             :white_check_mark: <https://github.com/nationalarchives/${{ inputs.repo-name }}/actions/runs/${{ github.run_id }}|Approve the workflow>
           slack-url: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -1,4 +1,4 @@
-name: TDR Terraform apply
+name: TDR Terraform plan and apply
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -14,6 +14,10 @@ on:
         required: true
       WORKFLOW_PAT:
         required: true
+      SLACK_WEBHOOK:
+        required: true
+      ACCOUNT_NUMBER:
+        required: true
 jobs:
   setup:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -1,0 +1,120 @@
+name: TDR Terraform apply
+on:
+  workflow_call:
+    inputs:
+      working-directory:
+        type: string
+        required: false
+        default: .
+      repo-name:
+        type: string
+        required: true
+    secrets:
+      MANAGEMENT_ACCOUNT:
+        required: true
+      WORKFLOW_PAT:
+        required: true
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    outputs:
+      account-number-secret: ${{ steps.set-environment-names.outputs.account_number_secret }}
+      title-environment: ${{ steps.set-environment-names.outputs.title_environment }}
+    steps:
+      - id: set-environment-names
+        run: |
+          env = "${{ inputs.environment }}"
+          print(f"::set-output name=account_number_secret::{env.upper()}_ACCOUNT_NUMBER")
+          print(f"::set-output name=title_environment::{env.title()}")
+        shell: python
+  plan:
+    runs-on: ubuntu-latest
+    needs: setup
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          token: ${{ secrets.WORKFLOW_PAT }}
+      - name: Configure AWS credentials for Lambda
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/TDRGithubTerraformAssumeRole${{ needs.setup.outputs.title-environment }}
+          aws-region: eu-west-2
+          role-session-name: TerraformRole
+      - name: Terraform Plan
+        id: plan
+        env:
+          GITHUB_OWNER: nationalarchives
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+          TF_VAR_tdr_account_number: ${{ secrets[needs.setup.outputs.account-number-secret] }}
+        run: |
+          terraform init
+          terraform workspace select ${{ inputs.environment }}
+          pip install boto3
+          terraform plan -no-color -out=out > /dev/null
+          terraform show -no-color out > out.plan
+          python .github/scripts/logs.py out.plan "${{ github.run_id }}${{ github.run_attempt }}" ${{ inputs.environment }}
+      - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
+        with:
+          message: |
+            :book: Terraform plan ready for environment ${{ inputs.environment }}
+            :log: View the <${{ steps.plan.outputs.log-url }}|plan logs> in the management account.
+            :white_check_mark: <https://github.com/nationalarchives/${{ inputs.repo-name }}/actions/runs/${{ github.run_id }}|Approve the workflow>
+          slack-url: ${{ secrets.SLACK_WEBHOOK }}
+  apply:
+    runs-on: ubuntu-latest
+    needs:
+      - plan
+      - setup
+    environment: ${{ inputs.environment }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+          token: ${{ secrets.WORKFLOW_PAT }}
+      - name: Configure AWS credentials for Lambda
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/TDRGithubTerraformAssumeRole${{ needs.setup.outputs.title-environment }}
+          aws-region: eu-west-2
+          role-session-name: TerraformRole
+      - name: Run apply
+        env:
+          GITHUB_OWNER: nationalarchives
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
+          TF_VAR_tdr_account_number: ${{ secrets.ACCOUNT_NUMBER }}
+        run: |
+          terraform init
+          terraform workspace select ${{ inputs.environment }}
+          terraform apply --auto-approve > /dev/null
+      - id: next-tag
+        uses: nationalarchives/tdr-github-actions/.github/actions/get-next-version@main
+        with:
+          repo-name: ${{ inputs.repo-name }}
+      - run: |
+          git tag ${{ steps.next-tag.outputs.next-version }}
+          git push origin ${{ steps.next-tag.outputs.next-version }}
+          git branch -f release-${{ inputs.environment }} HEAD
+          git push -f origin release-${{ inputs.environment }}
+      - name: Send failure message
+        if: failure()
+        uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
+        with:
+          message: ":warning: ${{ inputs.repo-name }} deploy failed for ${{ inputs.environment }}"
+          slack-url: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Send success message
+        uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
+        with:
+          message: ":white_check_mark: ${{ inputs.repo-name }} deploy successful for ${{ inputs.environment }}"
+          slack-url: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Run E2E tests
+        if: inputs.environment != 'prod'
+        uses: octokit/request-action@v2.x
+        with:
+          route: POST /repos/nationalarchives/tdr-e2e-tests/actions/workflows/ci.yml/dispatches
+          ref: master
+          inputs: "{\"environment\": \"${{ inputs.environment }}\"}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
This is the job that runs terraform plan, uploads the plan to Cloudwatch and then requests approval to apply. It's mostly lifted from the job in tdr-terraform-environments.

The reason I'm splitting it out into here is because we have other terraform apply jobs like the AWS accounts deploy so I think this is worth it.

The only slightly annoying part is that you have to pass INTG_ACCOUNT_NUMBER, STAGING_ACCOUNT_NUMBER and PROD_ACCOUNT_NUMBER. The plan step is run outside of the GitHub environment which means we don't have to approve that step but because of that, we need to pass all three accounts because the reusable workflow doesn't know in advance which one it will need.