### PR TITLE
Add script to check deployed environment variables

### DIFF
--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -42,6 +42,23 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_NUMBER }}:role/${{ steps.role-name.outputs.role-name }}
           aws-region: eu-west-2
           role-session-name: ECRLogin
+      - run: pip install boto3
+      - name: Check deployed environment variables
+        shell: python
+        run: |
+            from sys import exit
+            from re import findall
+            from os.path import exists
+            import boto3
+            conf = "src/main/resources/application.conf"
+            if exists(conf):
+              with open(conf) as file:
+                resp = boto3.client("lambda").get_function_configuration(FunctionName="tdr-${{ inputs.lambda-name }}-${{ inputs.environment }}")
+                lambda_env_vars = filter(lambda x: x != "AWS_LAMBDA_FUNCTION_NAME", resp["Environment"]["Variables"])
+                all_env_vars = set(findall("\\$\\{([A-Z_]*)\\}", file.read()))
+                exit(len(all_env_vars.difference(set(lambda_env_vars))))
+            else:
+              exit(0)
       - name: Deploy to lambda
         run: |
               aws lambda update-function-code --function-name tdr-${{ inputs.lambda-name }}-${{ inputs.environment }} --s3-bucket tdr-backend-code-mgmt --s3-key ${{ inputs.to-deploy }}/${{ inputs.deployment-package }} > /dev/null


### PR DESCRIPTION
This runs a python script inline:

It runs a regex search looking for the {ENV_VAR} lines in the conf file. Then it gets the env vars from the lambda
It then compares them and fails if any are missing in the lambda.

The python is all sqashed together because I can't have it in a separate file inside a custom action.