### PR TITLE
Put the lambda function name filter in the right place

### DIFF
--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -54,8 +54,8 @@ jobs:
             if exists(conf):
               with open(conf) as file:
                 resp = boto3.client("lambda").get_function_configuration(FunctionName="tdr-${{ inputs.lambda-name }}-${{ inputs.environment }}")
-                lambda_env_vars = filter(lambda x: x != "AWS_LAMBDA_FUNCTION_NAME", resp["Environment"]["Variables"])
-                all_env_vars = set(findall("\\$\\{([A-Z_]*)\\}", file.read()))
+                lambda_env_vars = resp["Environment"]["Variables"]
+                all_env_vars = filter(lambda x: x != "AWS_LAMBDA_FUNCTION_NAME", findall("\\$\\{([A-Z_]*)\\}", file.read()))
                 exit(len(all_env_vars.difference(set(lambda_env_vars))))
             else:
               exit(0)


### PR DESCRIPTION
The call to get the environment variables doesn't return
AWS_LAMBDA_FUNCTION_NAME as that's a "hidden" environment variable that
lambda provides.

It is sometimes in the application conf files though so it needs to be
filtered from those variables rather than the lambda variables.
