### PR TITLE
Update minor version on AWS libraries

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,3 +1,3 @@
 # Ignore any AWS updates for this minor version. They are released every day and cause a lot of pull requests.
 # The minor version will have to be incremented here when AWS release a new one.
-updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.17." } ]
+updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.18." } ]


### PR DESCRIPTION
We've been ignoring the 2.17.xx versions of the AWS libraries because they release new ones every day. They're up to 2.18.11 now so we can safely ignore all the 2.18 updates for now.