### PR TITLE
Update the ignore list

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,3 +1,3 @@
 # Ignore any AWS updates for this minor version. They are released every day and cause a lot of pull requests.
 # The minor version will have to be incremented here when AWS release a new one.
-updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.18." } ]
+updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.19." }, { groupId = "org.glassfish.jaxb", version = "2.3.7" }]

--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,3 +1,3 @@
 # Ignore any AWS updates for this minor version. They are released every day and cause a lot of pull requests.
 # The minor version will have to be incremented here when AWS release a new one.
-updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.19." }, { groupId = "org.glassfish.jaxb", version = "2.3.7" }]
+updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.19." }, { groupId = "org.glassfish.jaxb" }]

--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,3 +1,4 @@
 # Ignore any AWS updates for this minor version. They are released every day and cause a lot of pull requests.
 # The minor version will have to be incremented here when AWS release a new one.
+# The glassfish dependency is being ignored because the droid library used by the file format lambda needs this specific one.
 updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.19." }, { groupId = "org.glassfish.jaxb" }]


### PR DESCRIPTION
The AWS libraries are on 2.19.x now so we're getting updates every time as they're release every day. I've also added the jaxb library. This is only used by the new file format as it's needed by the Droid library. This will break if upgraded so we need to stop trying.