### PR TITLE
Version bump AWS SDK in ignore list.

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,4 +1,4 @@
 # Ignore any AWS updates for this minor version. They are released every day and cause a lot of pull requests.
 # The minor version will have to be incremented here when AWS release a new one.
 # The glassfish dependency is being ignored because the droid library used by the file format lambda needs this specific one.
-updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.19." }, { groupId = "org.glassfish.jaxb" }]
+updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.20." }, { groupId = "org.glassfish.jaxb" }]


### PR DESCRIPTION
AWS now have version 2.20. This is being deployed but we want to ignore
all the patch versions until 2.21 because they release them every day.
