### PR TITLE
Fix the inconsistent case.

### DIFF
--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -39,8 +39,8 @@ jobs:
           import os
           env = "${{ inputs.environment }}"
           with open(os.environ['GITHUB_OUTPUT'], 'a') as fh:
-            print(f"title-environment={env.title()}", file=fh)
-            print(f"account-number-secret={env.upper()}_ACCOUNT_NUMBER", file=fh)
+            print(f"title_environment={env.title()}", file=fh)
+            print(f"account_number_secret={env.upper()}_ACCOUNT_NUMBER", file=fh)
         shell: python
   plan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The variable being set on the GITHUB_OUTPUT file was `title-environment` but the outputs which were set to the next stage of the build was `title_environment` so the environment was going in empty so the role name didn't match one that exists in the management account so the assume role failed because the role doesn't exist.

This is Python so we'll stick with snake case as that's what it was before.
