### PR TITLE
Add AWS AMI account to allowed secrets

### DIFF
--- a/.github/actions/run-git-secrets/entrypoint.sh
+++ b/.github/actions/run-git-secrets/entrypoint.sh
@@ -3,4 +3,5 @@ git config --global --add safe.directory '/github/workspace' && \
 git-secrets --register-aws --global && \
 git-secrets --add --global '([^0-9])*[0-9]{12}([^0-9])*'
 git-secrets --add --global --allowed '1234'
+git-secrets --add --global --allowed '137112412989'
 git-secrets --scan


### PR DESCRIPTION
This account belongs to AWS and isn't secret. It's used when we're matching a given AMI.