### PR TITLE
Use 'java-version' input

### DIFF
--- a/.github/workflows/ecs_build.yml
+++ b/.github/workflows/ecs_build.yml
@@ -12,6 +12,7 @@ on:
         required: true
         type: string
       java-version:
+        description: "Version of Java required to build project"
         required: false
         type: string
         default: '11'

--- a/.github/workflows/ecs_build.yml
+++ b/.github/workflows/ecs_build.yml
@@ -11,6 +11,10 @@ on:
       image-name:
         required: true
         type: string
+      java-version:
+        required: false
+        type: string
+        default: '11'
     secrets:
       MANAGEMENT_ACCOUNT:
         required: true
@@ -34,7 +38,7 @@ jobs:
       - uses: coursier/cache-action@v6
       - uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
       - name: Configure AWS credentials from management account
         uses: aws-actions/configure-aws-credentials@v1-node16

--- a/.github/workflows/tdr_test.yml
+++ b/.github/workflows/tdr_test.yml
@@ -5,6 +5,11 @@ on:
       repo-name:
         required: true
         type: string
+      java-version:
+        description: "Version of Java required to build project"
+        required: false
+        type: string
+        default: '11'
       test-command:
         required: true
         type: string
@@ -28,6 +33,6 @@ jobs:
       - uses: coursier/cache-action@v6
       - uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: ${{ inputs.java-version }}
           distribution: 'temurin'
       - run: ${{ inputs.test-command }}


### PR DESCRIPTION
Not all ECS tasks are compatible with Java version 17

Optional input to set the Java version with default to Java version 11

Allow any tasks requiring higher version of Java to pass in required version and all other tasks to build correctly