### PR TITLE
Some lambdas deploy to 'mgmt' account

### DIFF
--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -82,7 +82,7 @@ jobs:
           message: ":warning: Build failed for ${{ inputs.lambda-name }}"
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - name: Run E2E tests
-        if: inputs.environment != 'prod'
+        if: inputs.environment != 'prod' || inputs.environment != 'mgmt'
         uses: octokit/request-action@v2.x
         with:
           route: POST /repos/nationalarchives/tdr-e2e-tests/actions/workflows/ci.yml/dispatches


### PR DESCRIPTION
Prevent e2e tests running for the ''mgmt' account