### PR TITLE
Make git tag optional

### DIFF
--- a/.github/workflows/terraform_apply.yml
+++ b/.github/workflows/terraform_apply.yml
@@ -20,6 +20,10 @@ on:
         type: string
         required: false
         default: 'tdr'
+      update-tag:
+        type: boolean
+        required: false
+        default: true
     secrets:
       MANAGEMENT_ACCOUNT:
         required: true
@@ -132,7 +136,9 @@ jobs:
         uses: nationalarchives/tdr-github-actions/.github/actions/get-next-version@main
         with:
           repo-name: ${{ inputs.repo-name }}
-      - run: |
+      - name: Run git tag
+        if: ${{ inputs.update-tag }}
+        run: |
           git tag ${{ steps.next-tag.outputs.next-version }}
           git push origin ${{ steps.next-tag.outputs.next-version }}
           git branch -f release-${{ inputs.environment }} HEAD


### PR DESCRIPTION
Makes the updating of the git tag optional so that repositories like the reference generator which uses both lambda_build.yml and terraform_apply.yml only update the tag once instead of twice.