### PR TITLE
fix: Checkout deployed tag at outset of workflow so that release branch is updated correctly

### DIFF
--- a/.github/workflows/ecs_deploy.yml
+++ b/.github/workflows/ecs_deploy.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: refs/tags/${{ inputs.to-deploy }}
       - name: Configure AWS credentials for ECR
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
@@ -70,8 +72,7 @@ jobs:
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - name: Update release branch
         run: |
-          git fetch origin refs/tags/${{ inputs.to-deploy }}
-          git branch -f release-${{ inputs.environment }} ${{ inputs.to-deploy }}
+          git branch -f release-${{ inputs.environment }} HEAD
           git push -f origin release-${{ inputs.environment }}
       - name: Send failure message
         uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main

--- a/.github/workflows/ecs_deploy.yml
+++ b/.github/workflows/ecs_deploy.yml
@@ -70,6 +70,7 @@ jobs:
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - name: Update release branch
         run: |
+          git fetch origin refs/tags/${{ inputs.to-deploy }}
           git branch -f release-${{ inputs.environment }} ${{ inputs.to-deploy }}
           git push -f origin release-${{ inputs.environment }}
       - name: Send failure message

--- a/.github/workflows/ecs_deploy.yml
+++ b/.github/workflows/ecs_deploy.yml
@@ -70,7 +70,7 @@ jobs:
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - name: Update release branch
         run: |
-          git branch -f release-${{ inputs.environment }} HEAD
+          git branch -f release-${{ inputs.environment }} ${{ inputs.to-deploy }}
           git push -f origin release-${{ inputs.environment }}
       - name: Send failure message
         uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with: 
+          ref: refs/tags/${{ inputs.to-deploy }}
       - id: role-name
         run: |
           import os
@@ -77,8 +79,7 @@ jobs:
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - name: Update release branch
         run: |
-          git fetch origin refs/tags/${{ inputs.to-deploy }}
-          git branch -f release-${{ inputs.environment }} ${{ inputs.to-deploy }}
+          git branch -f release-${{ inputs.environment }} HEAD
           git push -f origin release-${{ inputs.environment }}
       - name: Send failure message
         uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -77,6 +77,7 @@ jobs:
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - name: Update release branch
         run: |
+          git fetch origin refs/tags/${{ inputs.to-deploy }}
           git branch -f release-${{ inputs.environment }} ${{ inputs.to-deploy }}
           git push -f origin release-${{ inputs.environment }}
       - name: Send failure message

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -77,7 +77,7 @@ jobs:
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
       - name: Update release branch
         run: |
-          git branch -f release-${{ inputs.environment }} HEAD
+          git branch -f release-${{ inputs.environment }} ${{ inputs.to-deploy }}
           git push -f origin release-${{ inputs.environment }}
       - name: Send failure message
         uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main


### PR DESCRIPTION
At present, by leaving the arguments to the `checkout` action blank we checkout the calling branch (generally `master`/`main`) whilst running the our deploy workflow. This means that we update our release branch after deployment, it is set to the version tag at the current `HEAD`, regardless of whether a rollback is being performed, or if a higher environment is being deployed to a tagged version behind the latest merged change. 

By checking out with the tag of the deployed version, we can ensure that our release branches are accurately tagged moving forward.

---
#### Test Plan
Deployed `tdr-transfer-frontend` on intg from `master` to a version prior. Verified that the `intg-release` branch remained at the latest commit from `master`. Redeployed from `master` up to the current version. Deployed from a branch pointing at the `ecs_deploy` workflow on this PR to a version prior. Verified that the `intg-release` branch was successfully updated to point at the commit associated with the prior version.