### PR TITLE
Remove `tdr-backend-check-performance` from the repo list

### DIFF
--- a/repos.md
+++ b/repos.md
@@ -3,7 +3,6 @@
 - nationalarchives/tdr-auth-server:scala-steward-dependencies
 - nationalarchives/tdr-auth-utils:scala-steward-dependencies
 - nationalarchives/tdr-aws-utils:scala-steward-dependencies
-- nationalarchives/tdr-backend-check-performance:scala-steward-dependencies
 - nationalarchives/tdr-backend-checks-utils:scala-steward-dependencies
 - nationalarchives/tdr-checksum:scala-steward-dependencies
 - nationalarchives/tdr-consignment-api:scala-steward-dependencies


### PR DESCRIPTION
This repo isn't being used and seems to be causing issues when running the `.github/workflows/create-dependencies-pull-requests.yml`