### PR TITLE
Add 60s sleep to avoid hitting secondary rate limit

### DIFF
--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -39,5 +39,6 @@ jobs:
                 echo "There are no updates in $repo"
             fi
           done
+          sleep 60s
         env:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
Seems we are hitting the secondary rate limit https://github.com/nationalarchives/tdr-github-actions/actions/runs/8225666597/job/22490992609#step:4:20 Adding a 60s sleep between gh calls.
