### PR TITLE
Mitigations against hard failures in scala steward dependencies PR creation script

### DIFF
--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -36,7 +36,7 @@ jobs:
               response=$(gh api /repos/$repo/pulls \
                 -f title="Scala Steward Updates" \
                 -f base=$default_branch \
-                -f head=scala-steward-dependencies 2>&1)
+                -f head=scala-steward-dependencies 2>&1 || true)
             
               if echo "$response" | grep -q "422 Unprocessable Entity"; then
                 echo "[INFO] 422 error encountered for $repo:"

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -22,10 +22,7 @@ jobs:
             done < repos.md
             echo -e "::set-output name=repos::$repos_content"
         shell: bash
-
-      - name: Install jq
-        run: sudo apt-get update && sudo apt-get install -y jq
-
+        
       - name: Create Pull Request
         run: |
           for repo in ${{ steps.read-repos.outputs.repos }}; do
@@ -39,7 +36,7 @@ jobs:
               response=$(gh api /repos/$repo/pulls \
                 -f title="Scala Steward Updates" \
                 -f base=$default_branch \
-                -f head=scala-steward-dependencies 2>&1) # Capture all output including errors
+                -f head=scala-steward-dependencies 2>&1)
             
               if echo "$response" | grep -q "422 Unprocessable Entity"; then
                 echo "[INFO] 422 error encountered for $repo:"

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -23,6 +23,9 @@ jobs:
             echo -e "::set-output name=repos::$repos_content"
         shell: bash
 
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
       - name: Create Pull Request
         run: |
           for repo in ${{ steps.read-repos.outputs.repos }}; do
@@ -30,14 +33,23 @@ jobs:
             default_branch=$(gh api /repos/$repo -q '.default_branch')
             scala_steward_branch=$(gh api /repos/$repo/commits/refs/heads/scala-steward-dependencies -q '.sha')
             main=$(gh api /repos/$repo/commits/refs/heads/$default_branch -q '.sha')
+            diff=$(gh api /repos/$repo/compare/$main...scala-steward-dependencies -q '.files | length')
             
-            if [[ $scala_steward_branch != $main ]]; then
-                gh api /repos/$repo/pulls \
-                  -f title="Scala Steward Updates" \
-                  -f base=$default_branch \
-                  -f head=scala-steward-dependencies
+            if [[ $diff -gt 0 ]]; then
+              response=$(gh api /repos/$repo/pulls \
+                -f title="Scala Steward Updates" \
+                -f base=$default_branch \
+                -f head=scala-steward-dependencies 2>&1) # Capture all output including errors
+            
+              if echo "$response" | grep -q "422 Unprocessable Entity"; then
+                echo "[INFO] 422 error encountered for $repo:"
+                echo "$response" | jq -r '.message, .errors[].message'  # Assuming response is in JSON format and jq is available
+              else
+                echo "Pull request created successfully for $repo."
+                echo "$response"
+              fi
             else
-                echo "There are no updates in $repo"
+              echo "There are no updates in $repo"
             fi
           done
           sleep 60s

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -26,7 +26,6 @@ jobs:
       - name: Create Pull Request
         run: |
           for repo in ${{ steps.read-repos.outputs.repos }}; do
-            echo "Creating pull request for $repo"
             default_branch=$(gh api /repos/$repo -q '.default_branch')
             scala_steward_branch=$(gh api /repos/$repo/commits/refs/heads/scala-steward-dependencies -q '.sha')
             main=$(gh api /repos/$repo/commits/refs/heads/$default_branch -q '.sha')
@@ -34,13 +33,18 @@ jobs:
             pr_exists=$(gh api repos/$repo/pulls \
                 --jq '.[] | select(.head.ref == "scala-steward-dependencies" and .base.ref == "'$default_branch'" and .state == "open")' 2>&1)
             if [[ $diff -gt 0 && !$pr_exists ]]; then
+              echo $pr_exists
+              echo "Creating pull request for $repo"
               response=$(gh api /repos/$repo/pulls \
                 -f title="Scala Steward Updates" \
                 -f base=$default_branch \
                 -f head=scala-steward-dependencies 2>&1 || true)
               echo "Response received for $repo pull request: $response"
             else
-              echo "There are no updates in $repo"
+              if [[ $diff == 0 ]]
+                echo "There are no updates in $repo"
+              elif [[ $pr_exists ]]
+                echo "A PR already exists for the scala steward dependency branch in $repo"
             fi
           done
           sleep 60s

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -30,10 +30,11 @@ jobs:
             scala_steward_branch=$(gh api /repos/$repo/commits/refs/heads/scala-steward-dependencies -q '.sha')
             main=$(gh api /repos/$repo/commits/refs/heads/$default_branch -q '.sha')
             diff=$(gh api /repos/$repo/compare/$main...scala-steward-dependencies -q '.files | length')
-            pr_exists=$(gh api repos/$repo/pulls \
-                --jq '.[] | select(.head.ref == "scala-steward-dependencies" and .base.ref == "'$default_branch'" and .state == "open")' 2>&1)
-            if [[ $diff -gt 0 && !$pr_exists ]]; then
-              echo $pr_exists
+            existing_pull_requests=$(gh api repos/{owner}/{repo}/pulls)
+            scala_steward_pull_requests=$(echo "$pull_requests" | jq '.[] | select(.head.ref == "scala-steward-dependencies" and .base.ref == "'$default_branch'" and .state == "open")'
+            num_pull_requests=$(echo "$scala_steward_pull_requests" | jq length)
+            echo "Number of pull requests: $num_pull_requests"
+            if [[ $diff -gt 0 && $num_pull_requests == 0 ]]; then
               echo "Creating pull request for $repo"
               response=$(gh api /repos/$repo/pulls \
                 -f title="Scala Steward Updates" \

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -30,21 +30,19 @@ jobs:
             scala_steward_branch=$(gh api /repos/$repo/commits/refs/heads/scala-steward-dependencies -q '.sha')
             main=$(gh api /repos/$repo/commits/refs/heads/$default_branch -q '.sha')
             diff=$(gh api /repos/$repo/compare/$main...scala-steward-dependencies -q '.files | length')
-            existing_pull_requests=$(gh api repos/$repo/pulls)
-            scala_steward_pull_requests=$(echo "$pull_requests" | jq '.[] | select(.head.ref == "scala-steward-dependencies" and .base.ref == "'$default_branch'" and .state == "open")')
-            num_pull_requests=$(echo "$scala_steward_pull_requests" | jq length)
+            num_pull_requests=$(gh api repos/$repo/pulls --jq '[.[] | select(.head.ref == "scala-steward-dependencies" and .base.ref == "'$default_branch'" and .state == "open")] | length')
             echo "Number of pull requests: $num_pull_requests"
             if [[ $diff -gt 0 && $num_pull_requests == 0 ]]; then
               echo "Creating pull request for $repo"
               response=$(gh api /repos/$repo/pulls \
                 -f title="Scala Steward Updates" \
                 -f base=$default_branch \
-                -f head=scala-steward-dependencies 2>&1 || true)
+                -f head=scala-steward-dependencies 2>&1)
               echo "Response received for $repo pull request: $response"
             else
               if [[ $diff == 0 ]]; then
                 echo "There are no updates in $repo"
-              elif [[ $pr_exists ]]; then
+              elif [[ $num_pull_requests -gt 0 ]]; then
                 echo "A PR already exists for the scala steward dependency branch in $repo"
               fi
             fi

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -31,7 +31,7 @@ jobs:
             main=$(gh api /repos/$repo/commits/refs/heads/$default_branch -q '.sha')
             diff=$(gh api /repos/$repo/compare/$main...scala-steward-dependencies -q '.files | length')
             existing_pull_requests=$(gh api repos/{owner}/{repo}/pulls)
-            scala_steward_pull_requests=$(echo "$pull_requests" | jq '.[] | select(.head.ref == "scala-steward-dependencies" and .base.ref == "'$default_branch'" and .state == "open")'
+            scala_steward_pull_requests=$(echo "$pull_requests" | jq '.[] | select(.head.ref == "scala-steward-dependencies" and .base.ref == "'$default_branch'" and .state == "open")')
             num_pull_requests=$(echo "$scala_steward_pull_requests" | jq length)
             echo "Number of pull requests: $num_pull_requests"
             if [[ $diff -gt 0 && $num_pull_requests == 0 ]]; then

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -30,7 +30,7 @@ jobs:
             scala_steward_branch=$(gh api /repos/$repo/commits/refs/heads/scala-steward-dependencies -q '.sha')
             main=$(gh api /repos/$repo/commits/refs/heads/$default_branch -q '.sha')
             diff=$(gh api /repos/$repo/compare/$main...scala-steward-dependencies -q '.files | length')
-            existing_pull_requests=$(gh api repos/{owner}/{repo}/pulls)
+            existing_pull_requests=$(gh api repos/$repo/pulls)
             scala_steward_pull_requests=$(echo "$pull_requests" | jq '.[] | select(.head.ref == "scala-steward-dependencies" and .base.ref == "'$default_branch'" and .state == "open")')
             num_pull_requests=$(echo "$scala_steward_pull_requests" | jq length)
             echo "Number of pull requests: $num_pull_requests"

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -31,7 +31,6 @@ jobs:
             main=$(gh api /repos/$repo/commits/refs/heads/$default_branch -q '.sha')
             diff=$(gh api /repos/$repo/compare/$main...scala-steward-dependencies -q '.files | length')
             num_pull_requests=$(gh api repos/$repo/pulls --jq '[.[] | select(.head.ref == "scala-steward-dependencies" and .base.ref == "'$default_branch'" and .state == "open")] | length')
-            echo "Number of pull requests: $num_pull_requests"
             if [[ $diff -gt 0 && $num_pull_requests == 0 ]]; then
               echo "Creating pull request for $repo"
               response=$(gh api /repos/$repo/pulls \

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -38,12 +38,7 @@ jobs:
                 -f base=$default_branch \
                 -f head=scala-steward-dependencies 2>&1 || true)
             
-              if echo "$response" | grep -q "422 Unprocessable Entity"; then
-                echo "[INFO] 422 error encountered for $repo:"
-                echo "$response" | jq -r '.message, .errors[].message'  # Assuming response is in JSON format and jq is available
-              else
-                echo "Pull request created successfully for $repo."
-                echo "$response"
+              echo "Response received for $repo pull request: $response"
               fi
             else
               echo "There are no updates in $repo"

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -41,10 +41,11 @@ jobs:
                 -f head=scala-steward-dependencies 2>&1 || true)
               echo "Response received for $repo pull request: $response"
             else
-              if [[ $diff == 0 ]]
+              if [[ $diff == 0 ]]; then
                 echo "There are no updates in $repo"
-              elif [[ $pr_exists ]]
+              elif [[ $pr_exists ]]; then
                 echo "A PR already exists for the scala steward dependency branch in $repo"
+              fi
             fi
           done
           sleep 60s

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -31,8 +31,9 @@ jobs:
             scala_steward_branch=$(gh api /repos/$repo/commits/refs/heads/scala-steward-dependencies -q '.sha')
             main=$(gh api /repos/$repo/commits/refs/heads/$default_branch -q '.sha')
             diff=$(gh api /repos/$repo/compare/$main...scala-steward-dependencies -q '.files | length')
-            
-            if [[ $diff -gt 0 ]]; then
+            pr_exists=$(gh api repos/$repo/pulls \
+                --jq '.[] | select(.head.ref == "scala-steward-dependencies" and .base.ref == "'$default_branch'" and .state == "open")' 2>&1)
+            if [[ $diff -gt 0 && !$pr_exists ]]; then
               response=$(gh api /repos/$repo/pulls \
                 -f title="Scala Steward Updates" \
                 -f base=$default_branch \

--- a/.github/workflows/create-dependencies-pull-requests.yml
+++ b/.github/workflows/create-dependencies-pull-requests.yml
@@ -37,9 +37,7 @@ jobs:
                 -f title="Scala Steward Updates" \
                 -f base=$default_branch \
                 -f head=scala-steward-dependencies 2>&1 || true)
-            
               echo "Response received for $repo pull request: $response"
-              fi
             else
               echo "There are no updates in $repo"
             fi


### PR DESCRIPTION
- To determine whether there have been updates to the scala steward repo, check the length of `diff`ing the branches rather than comparing the SHAs of each branch's tip (if `scala-steward-dependencies` has merged in the default branch, the content will be identical but the hashes different, causing a failure)
- Don't attempt to create a pull request if there is already a pull request open for `scala-steward-dependencies` into the default branch