### PR TITLE
Update test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,4 +25,4 @@ jobs:
           slack-url: https://example.com
       - run: exit 1
         continue-on-error: false
-        if: steps.slack-send.outputs.status != 200
+        if: steps.slack-send.outputs.status != 405


### PR DESCRIPTION
example.com returns 405 if you try to post. Considering we're just checking the slack send actions sends something sane, we could just check for 405 here. 

It's a bit pointless but not entirely.