### PR TITLE
Change s3 bucket prefix for code deployment

### DIFF
--- a/.github/workflows/lambda_build.yml
+++ b/.github/workflows/lambda_build.yml
@@ -66,7 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.WORKFLOW_PAT }}
         run: |
           ${{ inputs.build-command }}
-          aws s3 cp ${{ inputs.artifact-path }}/${{ inputs.artifact-name }}.${{ inputs.artifact-file-type }} s3://tdr-backend-code-mgmt/${{ steps.next-tag.outputs.next-version }}/${{ inputs.artifact-name }}.${{ inputs.artifact-file-type }}
+          aws s3 cp ${{ inputs.artifact-path }}/${{ inputs.artifact-name }}.${{ inputs.artifact-file-type }} s3://tdr-backend-code-mgmt/${{ inputs.artifact-name }}/${{ steps.next-tag.outputs.next-version }}/${{ inputs.artifact-name }}.${{ inputs.artifact-file-type }}
           git tag ${{ steps.next-tag.outputs.next-version }}
           git push origin ${{ steps.next-tag.outputs.next-version }}
           gh release create ${{ steps.next-tag.outputs.next-version }} ${{ inputs.artifact-path }}/${{ inputs.artifact-name }}.${{ inputs.artifact-file-type }}

--- a/.github/workflows/lambda_deploy.yml
+++ b/.github/workflows/lambda_deploy.yml
@@ -76,7 +76,7 @@ jobs:
           if [ -n "${{ inputs.image-name }}" ]; then
            aws lambda update-function-code --function-name ${{ inputs.project }}-${{ inputs.lambda-name }}-${{ inputs.environment }} --image-uri ${{ secrets.MANAGEMENT_ACCOUNT}}.dkr.ecr.eu-west-2.amazonaws.com/${{ inputs.image-name }}:${{ inputs.environment }} > /dev/null
           else
-           aws lambda update-function-code --function-name ${{ inputs.project }}-${{ inputs.lambda-name }}-${{ inputs.environment }} --s3-bucket tdr-backend-code-mgmt --s3-key ${{ inputs.to-deploy }}/${{ inputs.deployment-package }} > /dev/null 
+           aws lambda update-function-code --function-name ${{ inputs.project }}-${{ inputs.lambda-name }}-${{ inputs.environment }} --s3-bucket tdr-backend-code-mgmt --s3-key ${{ inputs.lambda-name }}/${{ inputs.to-deploy }}/${{ inputs.deployment-package }} > /dev/null 
           fi
            aws lambda wait function-updated --function-name ${{ inputs.project }}-${{ inputs.lambda-name }}-${{ inputs.environment }} > /dev/null
       - name: Send success message


### PR DESCRIPTION
Existing form of the prefix makes it very hard to manage the contents of the s3 bucket used for code deployments