### PR TITLE
Ignore Open Telemetry version updates

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,4 +1,5 @@
 # Ignore any AWS updates for this minor version. They are released every day and cause a lot of pull requests.
 # The minor version will have to be incremented here when AWS release a new one.
 # The glassfish dependency is being ignored because the droid library used by the file format lambda needs this specific one.
-updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.20." }, { groupId = "org.glassfish.jaxb" }]
+# Open Telemetry is being ignored as latest version causing spike in AWS CloudWatch costs
+updates.ignore = [ { groupId = "software.amazon.awssdk", version = "2.20." }, { groupId = "org.glassfish.jaxb" }, groupId = "io.opentelemetry"]


### PR DESCRIPTION
Latest version of Open Telemetry caused large spike in AWS CloudWatch costs

Pinning for now until investigation into the cause