### PR TITLE
Fix `tdr_test.yml` run command

### DIFF
--- a/.github/workflows/tdr_test.yml
+++ b/.github/workflows/tdr_test.yml
@@ -60,4 +60,4 @@ jobs:
       - name: Run tests
         env:
           TEST_COMMAND: ${{ inputs.test-command }}
-        run: $TEST_COMMAND
+        run: eval "$TEST_COMMAND"


### PR DESCRIPTION
When test-command is a multi-line input (e.g., pip install -r requirements.txt\npython -m pytest), using bare $TEST_COMMAND without quotes causes shell word splitting — the newline becomes a word separator, not a command separator. So bash tries to run pip install -r requirements.txt python -m pytest as a single command, making pip see -m as an invalid option.